### PR TITLE
Add gst-plugins-ugly and gst-vaapi

### DIFF
--- a/files/gst-plugins-ugly/gst-plugins-ugly.json
+++ b/files/gst-plugins-ugly/gst-plugins-ugly.json
@@ -1,0 +1,26 @@
+{
+    "name": "gst-plugins-ugly",
+    "buildsystem": "meson",
+    "builddir": true,
+    "config-opts": [
+        "-Ddoc=disabled",
+        "-Dtests=disabled"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-1.22.9.tar.xz",
+            "sha256": "0bf685d66015a01dd3fc1671b64a1c8acb321dd9d4ab9e05a29ab19782aa6236",
+            "x-checker-data": {
+                "type": "json",
+                "url": "https://gitlab.freedesktop.org/api/v4/projects/1357/repository/tags?search=^1.22.",
+                "version-query": ".[0].name",
+                "url-query": "\"https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-\" + $version + \".tar.xz\""
+            }
+        }
+    ]
+}

--- a/org.gnome.NetworkDisplays.json
+++ b/org.gnome.NetworkDisplays.json
@@ -18,10 +18,22 @@
         "--system-talk-name=org.freedesktop.NetworkManager",
         "--system-talk-name=org.fedoraproject.FirewallD1"
     ],
+    "add-extensions": {
+        "org.freedesktop.Platform.GStreamer.gstreamer-vaapi": {
+            "directory": "lib/gstreamer-1.0",
+            "version": 23.08,
+            "autodelete": false,
+            "no-autodownload": true,
+            "add-ld-path": "lib",
+            "download-if": "have-intel-gpu",
+            "autoprune-unless": "have-intel-gpu"
+        }
+    },
     "modules": [
         "shared-modules/intltool/intltool-0.51.json",
         "files/avahi/avahi.json",
         "files/firewalld/firewalld.json",
+        "files/gst-plugins-ugly/gst-plugins-ugly.json",
         "files/gst-rtsp-server/gst-rtsp-server.json",
         "files/libprotobuf-c/libprotobuf-c.json",
         "files/NetworkManager/NetworkManager.json",


### PR DESCRIPTION
For hardware encoding support, which gives a
noticeable performance boost on systems supporting it.

Fixes https://github.com/flathub/org.gnome.NetworkDisplays/issues/163