### PR TITLE
runtime: bump to gnome 47

### DIFF
--- a/files/gst-plugins-ugly/gst-plugins-ugly.json
+++ b/files/gst-plugins-ugly/gst-plugins-ugly.json
@@ -13,11 +13,11 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-1.22.12.tar.xz",
-            "sha256": "d59a1aaf8dd2cc416dc5b5c0b7aecd02b1811bf1229aa724e6c2a503d3799083",
+            "url": "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-1.24.8.tar.xz",
+            "sha256": "3dfc12bf0b766682b7d6e1e29a404b55e2375ba172d11900179738ae89b7a2d5",
             "x-checker-data": {
                 "type": "json",
-                "url": "https://gitlab.freedesktop.org/api/v4/projects/1357/repository/tags?search=^1.22.",
+                "url": "https://gitlab.freedesktop.org/api/v4/projects/1357/repository/tags?search=^1.24.",
                 "version-query": ".[0].name",
                 "url-query": "\"https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-\" + $version + \".tar.xz\""
             }

--- a/files/gst-rtsp-server/gst-rtsp-server.json
+++ b/files/gst-rtsp-server/gst-rtsp-server.json
@@ -15,11 +15,11 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://gstreamer.freedesktop.org/src/gst-rtsp-server/gst-rtsp-server-1.22.12.tar.xz",
-            "sha256": "bf6c7871e7cf3528e4ec87ddc2f2949691cd269f98e536482ae744c1405cf451",
+            "url": "https://gstreamer.freedesktop.org/src/gst-rtsp-server/gst-rtsp-server-1.24.8.tar.xz",
+            "sha256": "84ed2b34b8f581a418d8ab8eff7657635fcf83c8960f27065c6c47e52836ed02",
             "x-checker-data": {
                 "type": "json",
-                "url": "https://gitlab.freedesktop.org/api/v4/projects/1357/repository/tags?search=^1.22.",
+                "url": "https://gitlab.freedesktop.org/api/v4/projects/1357/repository/tags?search=^1.24.",
                 "version-query": ".[0].name",
                 "url-query": "\"https://gstreamer.freedesktop.org/src/gst-rtsp-server/gst-rtsp-server-\" + $version + \".tar.xz\""
             }

--- a/org.gnome.NetworkDisplays.json
+++ b/org.gnome.NetworkDisplays.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.NetworkDisplays",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-network-displays",
     "finish-args": [
@@ -15,17 +15,6 @@
         "--system-talk-name=org.freedesktop.NetworkManager",
         "--system-talk-name=org.fedoraproject.FirewallD1"
     ],
-    "add-extensions": {
-        "org.freedesktop.Platform.GStreamer.gstreamer-vaapi": {
-            "directory": "lib/gstreamer-1.0",
-            "version": 23.08,
-            "autodelete": false,
-            "no-autodownload": true,
-            "add-ld-path": "lib",
-            "download-if": "have-intel-gpu",
-            "autoprune-unless": "have-intel-gpu"
-        }
-    },
     "modules": [
         "shared-modules/intltool/intltool-0.51.json",
         "files/avahi/avahi.json",


### PR DESCRIPTION
org.freedesktop.Platform.GStreamer.gstreamer-vaapi doesn't exist anymore and has been moved to gst-plugins-bad which is included in the runtime