### PR TITLE
update runtime: GNOME 48

### DIFF
--- a/org.gnome.NetworkDisplays.json
+++ b/org.gnome.NetworkDisplays.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.NetworkDisplays",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-network-displays",
     "finish-args": [


### PR DESCRIPTION
Visual changes from LibAdwaita 1.7, including dark theme color changes and window and widget corner radius